### PR TITLE
Linked build of GDAL against libkml

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -55,7 +55,8 @@ else
 fi
 
 # Install libkml-dev (required by gdal)
-apt-get -q -y --no-install-recommends install libkml-dev=1.3.0-1
+echo "-----> Installing libkml dependency"
+apt-get -q -y --no-install-recommends install libkml-dev | indent
 
 vendor_lib "GDAL" "$GDAL_VERSION" "$VENDOR_DIR"
 vendor_lib "GEOS" "$GEOS_VERSION" "$VENDOR_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -55,7 +55,7 @@ else
 fi
 
 # Install libkml-dev (required by gdal)
-echo "-----> Installing libkml dependency"
+topic "-----> Installing libkml dependency"
 apt-get -q -y --no-install-recommends install libkml-dev | indent
 
 vendor_lib "GDAL" "$GDAL_VERSION" "$VENDOR_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -54,6 +54,9 @@ else
     PROJ_VERSION=$DEFAULT_PROJ_VERSION
 fi
 
+# Install libkml-dev (required by gdal)
+apt-get -q -y --no-install-recommends install libkml-dev=1.3.0-1
+
 vendor_lib "GDAL" "$GDAL_VERSION" "$VENDOR_DIR"
 vendor_lib "GEOS" "$GEOS_VERSION" "$VENDOR_DIR"
 vendor_lib "PROJ" "$PROJ_VERSION" "$VENDOR_DIR"

--- a/builds/Dockerfile-heroku-16
+++ b/builds/Dockerfile-heroku-16
@@ -1,7 +1,9 @@
 FROM heroku/heroku:16-build
 
 RUN apt-get -q update
-RUN apt-get -q -y --no-install-recommends install awscli
+RUN apt-get -q -y --no-install-recommends install \
+    awscli \
+    libkml-dev
 
 ADD . /heroku-geo-buildpack
 

--- a/builds/Dockerfile-heroku-18
+++ b/builds/Dockerfile-heroku-18
@@ -1,7 +1,9 @@
 FROM heroku/heroku:18-build
 
 RUN apt-get -q update
-RUN apt-get -q -y --no-install-recommends install awscli
+RUN apt-get -q -y --no-install-recommends install \
+    awscli \
+    libkml-dev
 
 ADD . /heroku-geo-buildpack
 

--- a/builds/gdal/gdal
+++ b/builds/gdal/gdal
@@ -16,7 +16,8 @@ deploy_gdal() {
     ./configure \
         --prefix=$output \
         --without-jasper \
-        --with-libkml
+        --with-libkml \
+        --disable-static
     make
     make install
 

--- a/builds/gdal/gdal
+++ b/builds/gdal/gdal
@@ -2,7 +2,7 @@
 
 deploy_gdal() {
     VERSION=$1
-    
+
     # workspace directory
     workspace="$(mktemp -d)"
 
@@ -13,7 +13,10 @@ deploy_gdal() {
     pushd $workspace
     curl http://download.osgeo.org/gdal/$VERSION/gdal-$VERSION.tar.gz -s -o - | tar zxf -
     pushd gdal-$VERSION
-    ./configure --prefix=$output --without-jasper
+    ./configure \
+        --prefix=$output \
+        --without-jasper \
+        --with-libkml
     make
     make install
 


### PR DESCRIPTION
Work in progress against #2 

### This PR:

- [x] installs libkml-dev in the build environment so that GDAL can perform its compile-time checks and link against it
- [x] links the gdal build against libkml
- [x] limits GDAL build to shared-only per the python buildpack behaviour (building both would cause a lot of apps to fly over violate heroku's soft slug size limit, I believe... the static lib is c.170mb as I recall)
- [ ] installs libkml-dev in the slug so GDAL can find it at runtime

### Checks required:
- [ ] Heroku staff to check that removing static libs really is a good idea (i.e. was it intentional that you added static back in?)

**Help needed** from @CaseyFaist or @KevinBrolly, if you don't mind?
I've made an attempt to `apt-get install` `libkml-dev` in the `bin/compile` script, but it's not working. I get: `E: Unable to locate package libkml-dev`, which is weird because it's in [the ubuntu universe repository](https://packages.ubuntu.com/bionic/libkml-dev).

I'm uninclined to use heroku-apt-buildpack to install it, because that'd mean you need two buildpacks rather than one; and I'm not at all familiar with the way heroku compiles and deploys slugs so not sure I have the library configured correctly either.

Any takers for help teasing out that last issue?


