### PR TITLE
Strip symbols from compiled assets before creating tarballs

### DIFF
--- a/builds/dependencies/libkml/libkml-1.3.0
+++ b/builds/dependencies/libkml/libkml-1.3.0
@@ -16,11 +16,14 @@ pushd $workspace
 
 curl -sL https://github.com/libkml/libkml/tarball/1.3.0 -s -o - | tar zxf -
 pushd libkml-libkml-0da164d
+
 cmake -DCMAKE_INSTALL_PREFIX=$output --enable-static=no
 make
 make install
 
 pushd $output
+for i in lib/*; do strip -s $i 2>/dev/null || /bin/true; done
+for i in bin/*; do strip -s $i 2>/dev/null || /bin/true; done
 tar -czf libkml-1.3.0.tar.gz *
 
 if [[ $S3_BUCKET && $AWS_ACCESS_KEY_ID && $AWS_SECRET_ACCESS_KEY ]]; then

--- a/builds/gdal/gdal
+++ b/builds/gdal/gdal
@@ -11,11 +11,13 @@ deploy_gdal() {
     curl http://download.osgeo.org/gdal/$VERSION/gdal-$VERSION.tar.gz -s -o - | tar zxf -
     pushd gdal-$VERSION
 
-    ./configure --prefix=$OUTPUT --enable-static=no --without-jasper --with-libkml=$OUTPUT
+    ./configure --prefix=$OUTPUT --enable-static=no --without-jasper --with-libkml=$OUTPUT --with-hide-internal-symbols
     make
     make install
 
     pushd $OUTPUT
+    for i in lib/*; do strip -s $i 2>/dev/null || /bin/true; done
+    for i in bin/*; do strip -s $i 2>/dev/null || /bin/true; done
     tar -czf GDAL-$VERSION.tar.gz *
 
     if [[ $S3_BUCKET && $AWS_ACCESS_KEY_ID && $AWS_SECRET_ACCESS_KEY ]]; then

--- a/builds/geos/geos
+++ b/builds/geos/geos
@@ -2,7 +2,7 @@
 
 deploy_geos() {
     VERSION=$1
-    
+
     # workspace directory
     workspace="$(mktemp -d)"
 
@@ -18,6 +18,8 @@ deploy_geos() {
     make install
 
     pushd $output
+    for i in lib/*; do strip -s $i 2>/dev/null || /bin/true; done
+    for i in bin/*; do strip -s $i 2>/dev/null || /bin/true; done
     tar -czf GEOS-$VERSION.tar.gz *
 
     if [[ $S3_BUCKET && $AWS_ACCESS_KEY_ID && $AWS_SECRET_ACCESS_KEY ]]; then

--- a/builds/proj/proj
+++ b/builds/proj/proj
@@ -2,7 +2,7 @@
 
 deploy_proj() {
     VERSION=$1
-    
+
     # workspace directory
     workspace="$(mktemp -d)"
 
@@ -18,6 +18,8 @@ deploy_proj() {
     make install
 
     pushd $output
+    for i in lib/*; do strip -s $i 2>/dev/null || /bin/true; done
+    for i in bin/*; do strip -s $i 2>/dev/null || /bin/true; done
     tar -czf PROJ-$VERSION.tar.gz *
 
     if [[ $S3_BUCKET && $AWS_ACCESS_KEY_ID && $AWS_SECRET_ACCESS_KEY ]]; then


### PR DESCRIPTION
By default, GDAL includes debug symbols in the compiled
libraries and binaries.

This patch runs alls libraries and binaries through
`strip -s` before gzipping for S3 upload.

GDAL also got an extra configure flag to remove internal
symbols during the build, shaving another MB from the archives.

Looking at the size of the tarballs we see the following changes:

Baseline master:

|  MB | File                                  |
| --: | ------------------------------------- |
|   2 | /tmp/tmp.35TOH895Ns/PROJ-5.2.0.tar.gz |
|  56 | /tmp/tmp.VDi6KURfEc/GDAL-2.4.0.tar.gz |
|  10 | /tmp/tmp.XH8LQVrIen/GEOS-3.7.2.tar.gz |
|  68 | **Total**                             |

Baseline + strip:

|  MB | File                                  |
| --: | ------------------------------------- |
|  17 | /tmp/tmp.Ck3svpj3AV/GDAL-2.4.0.tar.gz |
|   1 | /tmp/tmp.nkBO1r6GDV/PROJ-5.2.0.tar.gz |
|   1 | /tmp/tmp.tvBBt4zCRO/GEOS-3.7.2.tar.gz |
|  19 | **Total**                             |

Baseline + strip + --with-hide-internal-symbols:

|  MB | File                                  |
| --: | ------------------------------------- |
|  16 | /tmp/tmp.Ck3svpj3AV/GDAL-2.4.0.tar.gz |
|   1 | /tmp/tmp.nkBO1r6GDV/PROJ-5.2.0.tar.gz |
|   1 | /tmp/tmp.tvBBt4zCRO/GEOS-3.7.2.tar.gz |
|  18 | **Total**                             |

The same strategy for reducing the size of the compiled
assets is used by GDAL upstream for their official
Docker images.
