### PR TITLE
Set LIBRARY_PATH at runtime too

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -80,5 +80,6 @@ mkdir -p "$(dirname "$PROFILE_PATH")"
   echo 'export PROJ4_LIBRARY_PATH="$HOME/.heroku-geo-buildpack/vendor/lib/libproj.so"'
   echo 'export GDAL_DATA="$HOME/.heroku-geo-buildpack/vendor/share/gdal"'
   echo 'export PATH="$HOME/.heroku-geo-buildpack/vendor/bin:$PATH"'
+  echo 'export LIBRARY_PATH="$HOME/.heroku-geo-buildpack/vendor/lib:$LIBRARY_PATH"'
   echo 'export LD_LIBRARY_PATH="$HOME/.heroku-geo-buildpack/vendor/lib:$LD_LIBRARY_PATH"'
 } >> "$PROFILE_PATH"


### PR DESCRIPTION
Django's library location auto-detection relies upon the stdlib's `ctypes.util.find_library()`, which in Python versions earlier than Python 3.6, didn't check `LD_LIBRARY_PATH`, only `LIBRARY_PATH`:
https://docs.python.org/3/library/ctypes.html#finding-shared-libraries

Setting `LIBRARY_PATH` at runtime increases parity with the Python buildpack's legacy feature:
https://github.com/heroku/heroku-buildpack-python/blob/41f657fbff4dd90efa7705737bc6fee4fba05dba/bin/steps/geo-libs#L53-L57

And makes auto-detection work on Python <3.6.

Fixes #16.
Closes [W-8391584](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008J47RIAS/view).