### PR TITLE
Add missing build time path environment variables

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,9 +59,13 @@ vendor_lib "GDAL" "$GDAL_VERSION" "$VENDOR_DIR"
 vendor_lib "GEOS" "$GEOS_VERSION" "$VENDOR_DIR"
 vendor_lib "PROJ" "$PROJ_VERSION" "$VENDOR_DIR"
 
-# Add some environment variables that are available to the next buildpacks, to ensure that pip can find the
-# GDAL installation as this is needed to pip install GDAL
+# Set environment variables for later buildpacks, so that the GDAL installation
+# can be found when pip installing GDAL, or by Django (eg during collectstatic).
 {
+  echo "export GDAL_LIBRARY_PATH=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/lib/libgdal.so\""
+  echo "export GEOS_LIBRARY_PATH=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/lib/libgeos_c.so\""
+  echo "export PROJ4_LIBRARY_PATH=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/lib/libproj.so\""
+  echo "export GDAL_DATA=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/share/gdal\""
   echo "export PATH=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/bin:\$PATH\""
   echo "export LIBRARY_PATH=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/lib:\$LIBRARY_PATH\""
   echo "export LD_LIBRARY_PATH=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/lib:\$LD_LIBRARY_PATH\""


### PR DESCRIPTION
Ensures that all of the environment variables available at runtime are also available at build time. This is necessary since it's common for apps to be invoked at build time (eg for Django collectstatic), and often this means fully initialising the framework backends, which will fail if expected libraries are not found.

Fixes #15.
Closes [W-8429195](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008ir50IAA/view).