### PR TITLE
Add support for 3.4.2

### DIFF
--- a/builds/gdal/gdal-3.4.2.sh
+++ b/builds/gdal/gdal-3.4.2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# shellcheck disable=SC2164
+CURRENT_DIR="$(cd "$(dirname "$0")"; pwd)"
+ROOT_DIR=$(dirname "$CURRENT_DIR")
+
+# shellcheck source=builds/dependencies/utils.sh
+source "$ROOT_DIR/dependencies/utils.sh"
+
+# shellcheck source=builds/gdal/gdal.sh
+source "$(dirname "$0")/gdal.sh"
+
+WORKSPACE="$(mktemp -d)"
+OUTPUT="$(mktemp -d)"
+
+# Ensure we can find any dependencies
+export CPATH="$OUTPUT/include:$CPATH"
+export LIBRARY_PATH="$OUTPUT/lib:$LIBRARY_PATH"
+export LD_LIBRARY_PATH="$OUTPUT/lib:$LD_LIBRARY_PATH"
+
+# We want to include google's libkml in our gdal.sh build
+vendor_dependency "libkml" "1.3.0" "$OUTPUT"
+
+deploy_gdal "3.4.2" "$WORKSPACE" "$OUTPUT"


### PR DESCRIPTION
Hi 🖖

I was trying to use the buildpack for GeoDjango by specifying `GDAL_VERSION=3.4.2`, however the build fails with the following message:

```
-----> Building on the Heroku-20 stack
-----> Using buildpacks:
       1. https://github.com/heroku/heroku-geo-buildpack
       2. heroku/python
-----> Geo Packages (GDAL/GEOS/PROJ) app detected
-----> Installing GDAL-3.4.2
 !     Requested GDAL Version (3.4.2) is not available for this stack (heroku-20).
 !     Aborting.
 !     Push rejected, failed to compile Geo Packages (GDAL/GEOS/PROJ) app.
 !     Push failed
```
Unfortunately I don't exactly know how these files are connected and used, so I followed the pattern with the other two versions.

Fixes #24 