### PR TITLE
Add support for Heroku-22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
             image: heroku/heroku:18-build
           - name: heroku-20
             image: heroku/heroku:20-build
+          - name: heroku-22
+            image: heroku/heroku:22-build
     container: ${{ matrix.stack.image }}
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ test-heroku-20:
 	@docker run -v "$(shell pwd):/buildpack:ro" --rm -it -e "STACK=heroku-20" heroku/heroku:20-build bash -c '/buildpack/tests.sh'
 	@echo ""
 
+test-heroku-22:
+	@echo "Running tests in docker (heroku-22)..."
+	@docker run -v "$(shell pwd):/buildpack:ro" --rm -it -e "STACK=heroku-20" heroku/heroku:22-build bash -c '/buildpack/tests.sh'
+	@echo ""
+
 build-heroku-18:
 	@echo "Creating build environment (heroku-18)..."
 	@echo
@@ -17,7 +22,7 @@ build-heroku-18:
 	@echo
 	@echo "  $$ export S3_BUCKET='heroku-geo-buildpack' # Optional unless deploying"
 	@echo "  $$ export AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar  # Optional unless deploying"
-	@echo "  $$ ./builds/gdal/gdal-version"
+	@echo "  $$ ./builds/gdal/gdal-<version>.sh"
 	@echo
 	@docker run -e STACK="heroku-18" -it --rm buildenv-heroku-18
 
@@ -30,6 +35,19 @@ build-heroku-20:
 	@echo
 	@echo "  $$ export S3_BUCKET='heroku-geo-buildpack' # Optional unless deploying"
 	@echo "  $$ export AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar  # Optional unless deploying"
-	@echo "  $$ ./builds/gdal/gdal-version"
+	@echo "  $$ ./builds/gdal/gdal-<version>.sh"
 	@echo
 	@docker run -e STACK="heroku-20" -it --rm buildenv-heroku-20
+
+build-heroku-22:
+	@echo "Creating build environment (heroku-22)..."
+	@echo
+	@docker build --pull -f "$(shell pwd)/builds/Dockerfile-heroku-22" -t buildenv-heroku-22 .
+	@echo
+	@echo "Usage..."
+	@echo
+	@echo "  $$ export S3_BUCKET='heroku-geo-buildpack' # Optional unless deploying"
+	@echo "  $$ export AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar  # Optional unless deploying"
+	@echo "  $$ ./builds/gdal/gdal-<version>.sh"
+	@echo
+	@docker run -e STACK="heroku-22" -it --rm buildenv-heroku-22

--- a/builds/Dockerfile-heroku-22
+++ b/builds/Dockerfile-heroku-22
@@ -1,0 +1,7 @@
+FROM heroku/heroku:22-build
+
+RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli
+
+ADD . /heroku-geo-buildpack
+
+WORKDIR "/heroku-geo-buildpack"

--- a/builds/gdal/gdal.sh
+++ b/builds/gdal/gdal.sh
@@ -8,7 +8,7 @@ deploy_gdal() {
     # build and package gdal.sh
     pushd "$WORKSPACE" || exit 1
 
-    curl "http://download.osgeo.org/gdal/$VERSION/gdal-$VERSION.tar.gz" -s -o - | tar zxf -
+    curl "https://download.osgeo.org/gdal/$VERSION/gdal-$VERSION.tar.gz" -s -o - | tar zxf -
     pushd "gdal-$VERSION" || exit 1
 
     ./configure --prefix="$OUTPUT" --enable-static=no --without-jasper --with-libkml="$OUTPUT" --with-hide-internal-symbols

--- a/builds/geos/geos.sh
+++ b/builds/geos/geos.sh
@@ -11,7 +11,7 @@ deploy_geos() {
 
     # build and package geos.sh
     pushd "$workspace" || exit 1
-    curl "http://download.osgeo.org/geos/geos-$VERSION.tar.bz2" -s -o - | tar xjf -
+    curl "https://download.osgeo.org/geos/geos-$VERSION.tar.bz2" -s -o - | tar xjf -
     pushd "geos-$VERSION" || exit 1
     ./configure --prefix="$output" --enable-static=no
     make

--- a/builds/proj/proj.sh
+++ b/builds/proj/proj.sh
@@ -11,7 +11,7 @@ deploy_proj() {
 
     # build and package proj.sh
     pushd "$workspace" || exit 1
-    curl "http://download.osgeo.org/proj/proj-$VERSION.tar.gz" -s -o - | tar zxf -
+    curl "https://download.osgeo.org/proj/proj-$VERSION.tar.gz" -s -o - | tar zxf -
     pushd "proj-$VERSION" || exit 1
     ./configure --prefix="$output" --enable-static=no
     make


### PR DESCRIPTION
The binaries were generated by:
- Running `make build-heroku-22`
- Setting the AWS env vars inside that environment
- Running the build scripts for each dep/lib:
   ```
   ./builds/dependencies/libkml/libkml-1.3.0.sh
   ./builds/proj/proj-5.2.0.sh
   ./builds/geos/geos-3.7.2.sh
   ./builds/gdal/gdal-2.4.0.sh
   ./builds/gdal/gdal-2.4.2.sh
   ```

GUS-W-10346751.