### PR TITLE
Link to the docs from the "version not available" error message

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,6 +11,7 @@ vendor_lib() {
     mkdir -p "$VENDOR_DIR"
     if ! curl "${LIBRARY_URL}" -s | tar zxv -C "$VENDOR_DIR" &> /dev/null; then
       echo " !     Requested $LIBRARY Version ($VERSION) is not available for this stack ($STACK)."
+      echo " !     See: https://github.com/heroku/heroku-geo-buildpack#available-versions"
       echo " !     Aborting."
       exit 1
     fi


### PR DESCRIPTION
So that users don't have to figure out how to find out which versions are valid.

Links to:
https://github.com/heroku/heroku-geo-buildpack#available-versions

GUS-W-10346751.