### PR TITLE
Update default GEOS from 3.7.2 to 3.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Default Versions
 The buildpack will install the following versions by default *for new apps*:
 
 - GDAL: `2.4.0`
-- GEOS: `3.7.2`
+- GEOS:
+  - Heroku-18: `3.7.2`
+  - Heroku-20 + Heroku-22: `3.10.2`
 - PROJ: `5.2.0`
 
 *Existing apps* that don't specify an explicit version will continue to use the
@@ -39,7 +41,9 @@ Available Versions
 ------------------
 
 - GDAL: `2.4.0`, `2.4.2`
-- GEOS: `3.7.2`
+- GEOS:
+  - Heroku-18: `3.7.2`
+  - Heroku-20 + Heroku-22: `3.7.2`, `3.10.2`
 - PROJ: `5.2.0`
 
 Migrating from heroku/python GEOs support

--- a/bin/compile
+++ b/bin/compile
@@ -29,8 +29,13 @@ BP_DIR=$(cd "$(dirname "${0:-}")" || exit 1 ; cd ..; pwd)
 VENDOR_DIR="$BUILD_DIR/.heroku-geo-buildpack/vendor"
 
 DEFAULT_GDAL_VERSION="2.4.0"
-DEFAULT_GEOS_VERSION="3.7.2"
+DEFAULT_GEOS_VERSION="3.10.2"
 DEFAULT_PROJ_VERSION="5.2.0"
+
+if [[ "${STACK}" == "heroku-18" ]]; then
+    # Newer GEOS requires CMake 3.13+ which isn't available on Ubuntu 18.04.
+    DEFAULT_GEOS_VERSION="3.7.2"
+fi
 
 if [ -f "$ENV_DIR/GDAL_VERSION" ]; then
     GDAL_VERSION=$(cat "$ENV_DIR/GDAL_VERSION")

--- a/builds/geos/geos-3.10.2.sh
+++ b/builds/geos/geos-3.10.2.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# shellcheck source=builds/geos/geos.sh
+source "$(dirname "$0")/geos.sh"
+deploy_geos "3.10.2"

--- a/tests.sh
+++ b/tests.sh
@@ -40,8 +40,13 @@ testDefaultVersionInstall() {
   stdout=$(compile)
   assertEquals "0" "$?"
   assertContains "$stdout" "-----> Installing GDAL-2.4.0"
-  assertContains "$stdout" "-----> Installing GEOS-3.7.2"
   assertContains "$stdout" "-----> Installing PROJ-5.2.0"
+
+  if [[ "${STACK}" == "heroku-18" ]]; then
+    assertContains "$stdout" "-----> Installing GEOS-3.7.2"
+  else
+    assertContains "$stdout" "-----> Installing GEOS-3.10.2"
+  fi
 }
 
 testBuildpackEnv() {
@@ -55,12 +60,26 @@ testBuildpackEnv() {
   assertContains "$PROFILE" "C_INCLUDE_PATH=\"$BUILD_DIR/.heroku-geo-buildpack/vendor/include:\$C_INCLUDE_PATH\""
 }
 
-testAvailableVersionInstall() {
+testSpecifiedVersionInstall() {
   setEnvVar "GDAL_VERSION" "2.4.2"
+  setEnvVar "PROJ_VERSION" "5.2.0"
+
+  if [[ "${STACK}" == "heroku-18" ]]; then
+    setEnvVar "GEOS_VERSION" "3.7.2"
+  else
+    setEnvVar "GEOS_VERSION" "3.10.2"
+  fi
 
   stdout=$(compile)
   assertEquals "0" "$?"
   assertContains "$stdout" "-----> Installing GDAL-2.4.2"
+  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
+
+  if [[ "${STACK}" == "heroku-18" ]]; then
+    assertContains "$stdout" "-----> Installing GEOS-3.7.2"
+  else
+    assertContains "$stdout" "-----> Installing GEOS-3.10.2"
+  fi
 }
 
 testUnavailableVersionInstall() {


### PR DESCRIPTION
This will only affect new apps (or existing apps where the build cache is cleared) that don't specify an explicit GEOS version, and that are using Heroku-20 (or the unreleased Heroku-22).

To override the default, set the `GEOS_VERSION` env var to the desired version.

It was not possible to build GEOS 3.10.2 on Heroku-18, since it requires CMake 3.13+, which is newer than the CMake available on Ubuntu 18.04.

Changes:
https://github.com/libgeos/geos/blob/main/NEWS.md#changes-in-3100

GUS-W-10346751.