### PR TITLE
Add support for PROJ 8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Available Versions
 - GEOS:
   - Heroku-18: `3.7.2`
   - Heroku-20 + Heroku-22: `3.7.2`, `3.10.2`
-- PROJ: `5.2.0`
+- PROJ: `5.2.0`, `8.2.1`
 
 Migrating from heroku/python GEOs support
 -----------------------------------------

--- a/builds/Dockerfile-heroku-18
+++ b/builds/Dockerfile-heroku-18
@@ -1,6 +1,6 @@
 FROM heroku/heroku:18-build
 
-RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli
+RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli libsqlite3-dev sqlite3
 
 ADD . /heroku-geo-buildpack
 

--- a/builds/Dockerfile-heroku-20
+++ b/builds/Dockerfile-heroku-20
@@ -1,6 +1,6 @@
 FROM heroku/heroku:20-build
 
-RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli
+RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli libsqlite3-dev sqlite3
 
 ADD . /heroku-geo-buildpack
 

--- a/builds/Dockerfile-heroku-22
+++ b/builds/Dockerfile-heroku-22
@@ -1,6 +1,6 @@
 FROM heroku/heroku:22-build
 
-RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli
+RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli libsqlite3-dev sqlite3
 
 ADD . /heroku-geo-buildpack
 

--- a/builds/proj/proj-8.2.1.sh
+++ b/builds/proj/proj-8.2.1.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# shellcheck source=builds/proj/proj.sh
+source "$(dirname "$0")/proj.sh"
+deploy_proj "8.2.1"

--- a/tests.sh
+++ b/tests.sh
@@ -61,8 +61,10 @@ testBuildpackEnv() {
 }
 
 testSpecifiedVersionInstall() {
+  # The versions here should ideally not match the default versions,
+  # so that we're testing that it really overrides the defaults.
   setEnvVar "GDAL_VERSION" "2.4.2"
-  setEnvVar "PROJ_VERSION" "5.2.0"
+  setEnvVar "PROJ_VERSION" "8.2.1"
 
   if [[ "${STACK}" == "heroku-18" ]]; then
     setEnvVar "GEOS_VERSION" "3.7.2"
@@ -73,7 +75,7 @@ testSpecifiedVersionInstall() {
   stdout=$(compile)
   assertEquals "0" "$?"
   assertContains "$stdout" "-----> Installing GDAL-2.4.2"
-  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
+  assertContains "$stdout" "-----> Installing PROJ-8.2.1"
 
   if [[ "${STACK}" == "heroku-18" ]]; then
     assertContains "$stdout" "-----> Installing GEOS-3.7.2"


### PR DESCRIPTION
This is the newest PROJ that doesn't require the updated CMake based build script (9+ requires CMake, so will require further changes that aren't worth making for now).

Newer PROJ requires that the sqlite3 headers and binary be available during the build, so the Dockerfiles had to be updated accordingly.

The default PROJ remains unchanged for now, so apps wanting to use newer PROJ will need to set the env var `PROJ_VERSION` to `8.2.1`.

For changes, see:
https://proj.org/news.html

GUS-W-10346751.