### PR TITLE
Add support for GEOS 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can change the version of each library that will be installed by setting the
 Available Versions
 ------------------
 
-- GDAL: `2.4.0`, `2.4.2`
+- GDAL: `2.4.0`, `2.4.2`, `3.5.0`
 - GEOS:
   - Heroku-18: `3.7.2`
   - Heroku-20 + Heroku-22: `3.7.2`, `3.10.2`

--- a/builds/gdal/gdal-3.5.0.sh
+++ b/builds/gdal/gdal-3.5.0.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# shellcheck disable=SC2164
+CURRENT_DIR="$(cd "$(dirname "$0")"; pwd)"
+ROOT_DIR=$(dirname "$CURRENT_DIR")
+
+# shellcheck source=builds/dependencies/utils.sh
+source "$ROOT_DIR/dependencies/utils.sh"
+
+# shellcheck source=builds/gdal/gdal.sh
+source "$(dirname "$0")/gdal.sh"
+
+WORKSPACE="$(mktemp -d)"
+OUTPUT="$(mktemp -d)"
+
+# Ensure we can find any dependencies
+export CPATH="$OUTPUT/include:$CPATH"
+export LIBRARY_PATH="$OUTPUT/lib:$LIBRARY_PATH"
+export LD_LIBRARY_PATH="$OUTPUT/lib:$LD_LIBRARY_PATH"
+
+# We want to include google's libkml in our gdal.sh build
+vendor_dependency "libkml" "1.3.0" "$OUTPUT"
+
+# GDAL now requires PROJ at build time
+vendor_dependency "PROJ" "8.2.1" "$OUTPUT"
+
+deploy_gdal "3.5.0" "$WORKSPACE" "$OUTPUT"

--- a/builds/gdal/gdal.sh
+++ b/builds/gdal/gdal.sh
@@ -11,6 +11,8 @@ deploy_gdal() {
     curl "https://download.osgeo.org/gdal/$VERSION/gdal-$VERSION.tar.gz" -sSf -o - | tar zxf -
     pushd "gdal-$VERSION" || exit 1
 
+    # TODO: Once GDAL 3.5.0 is the oldest supported version, remove the `--without-jasper`
+    # usage, since it no longer does anything after https://github.com/OSGeo/gdal/pull/5269
     ./configure --prefix="$OUTPUT" --enable-static=no --without-jasper --with-libkml="$OUTPUT" --with-hide-internal-symbols
     make
     make install

--- a/tests.sh
+++ b/tests.sh
@@ -40,13 +40,14 @@ testDefaultVersionInstall() {
   stdout=$(compile)
   assertEquals "0" "$?"
   assertContains "$stdout" "-----> Installing GDAL-2.4.0"
-  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
 
   if [[ "${STACK}" == "heroku-18" ]]; then
     assertContains "$stdout" "-----> Installing GEOS-3.7.2"
   else
     assertContains "$stdout" "-----> Installing GEOS-3.10.2"
   fi
+
+  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
 }
 
 testBuildpackEnv() {
@@ -63,25 +64,15 @@ testBuildpackEnv() {
 testSpecifiedVersionInstall() {
   # The versions here should ideally not match the default versions,
   # so that we're testing that it really overrides the defaults.
-  setEnvVar "GDAL_VERSION" "2.4.2"
+  setEnvVar "GDAL_VERSION" "3.5.0"
+  setEnvVar "GEOS_VERSION" "3.7.2"
   setEnvVar "PROJ_VERSION" "8.2.1"
-
-  if [[ "${STACK}" == "heroku-18" ]]; then
-    setEnvVar "GEOS_VERSION" "3.7.2"
-  else
-    setEnvVar "GEOS_VERSION" "3.10.2"
-  fi
 
   stdout=$(compile)
   assertEquals "0" "$?"
-  assertContains "$stdout" "-----> Installing GDAL-2.4.2"
+  assertContains "$stdout" "-----> Installing GDAL-3.5.0"
+  assertContains "$stdout" "-----> Installing GEOS-3.7.2"
   assertContains "$stdout" "-----> Installing PROJ-8.2.1"
-
-  if [[ "${STACK}" == "heroku-18" ]]; then
-    assertContains "$stdout" "-----> Installing GEOS-3.7.2"
-  else
-    assertContains "$stdout" "-----> Installing GEOS-3.10.2"
-  fi
 }
 
 testUnavailableVersionInstall() {


### PR DESCRIPTION
The default GEOS version remains unchanged for now, so apps wanting to use newer GEOS will need to set the env var `GEOS_VERSION` to `3.5.0` (and also likely set `PROJ_VERSION` to a newer version too, eg `8.2.1`).

When updating to this version, you will need to make sure any packages that depend on it (eg the [GDAL](https://pypi.org/project/GDAL/) Python package) are updated to a matching/compatible version.

For changes, see:
https://github.com/OSGeo/gdal/blob/v3.5.0/NEWS.md

Closes #28.
Closes #30.
GUS-W-10346751.