### PR TITLE
Update default GDAL to 3.5.0 and PROJ to 8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Default Versions
 
 The buildpack will install the following versions by default *for new apps*:
 
-- GDAL: `2.4.0`
+- GDAL: `3.5.0`
 - GEOS:
   - Heroku-18: `3.7.2`
   - Heroku-20 + Heroku-22: `3.10.2`
-- PROJ: `5.2.0`
+- PROJ: `8.2.1`
 
 *Existing apps* that don't specify an explicit version will continue to use the
 version used by the last successful build (unless the build cache is cleared).

--- a/bin/compile
+++ b/bin/compile
@@ -28,9 +28,9 @@ BP_DIR=$(cd "$(dirname "${0:-}")" || exit 1 ; cd ..; pwd)
 
 VENDOR_DIR="$BUILD_DIR/.heroku-geo-buildpack/vendor"
 
-DEFAULT_GDAL_VERSION="2.4.0"
+DEFAULT_GDAL_VERSION="3.5.0"
 DEFAULT_GEOS_VERSION="3.10.2"
-DEFAULT_PROJ_VERSION="5.2.0"
+DEFAULT_PROJ_VERSION="8.2.1"
 
 if [[ "${STACK}" == "heroku-18" ]]; then
     # Newer GEOS requires CMake 3.13+ which isn't available on Ubuntu 18.04.

--- a/tests.sh
+++ b/tests.sh
@@ -39,7 +39,7 @@ setEnvVar () {
 testDefaultVersionInstall() {
   stdout=$(compile)
   assertEquals "0" "$?"
-  assertContains "$stdout" "-----> Installing GDAL-2.4.0"
+  assertContains "$stdout" "-----> Installing GDAL-3.5.0"
 
   if [[ "${STACK}" == "heroku-18" ]]; then
     assertContains "$stdout" "-----> Installing GEOS-3.7.2"
@@ -47,7 +47,7 @@ testDefaultVersionInstall() {
     assertContains "$stdout" "-----> Installing GEOS-3.10.2"
   fi
 
-  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
+  assertContains "$stdout" "-----> Installing PROJ-8.2.1"
 }
 
 testBuildpackEnv() {
@@ -64,15 +64,15 @@ testBuildpackEnv() {
 testSpecifiedVersionInstall() {
   # The versions here should ideally not match the default versions,
   # so that we're testing that it really overrides the defaults.
-  setEnvVar "GDAL_VERSION" "3.5.0"
+  setEnvVar "GDAL_VERSION" "2.4.0"
   setEnvVar "GEOS_VERSION" "3.7.2"
-  setEnvVar "PROJ_VERSION" "8.2.1"
+  setEnvVar "PROJ_VERSION" "5.2.0"
 
   stdout=$(compile)
   assertEquals "0" "$?"
-  assertContains "$stdout" "-----> Installing GDAL-3.5.0"
+  assertContains "$stdout" "-----> Installing GDAL-2.4.0"
   assertContains "$stdout" "-----> Installing GEOS-3.7.2"
-  assertContains "$stdout" "-----> Installing PROJ-8.2.1"
+  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
 }
 
 testUnavailableVersionInstall() {


### PR DESCRIPTION
Changes the default versions for new apps that don't set an explicit version, as follows:
- GDAL: `2.4.0` -> `3.5.0`
- PROJ: `5.2.0` -> `8.2.1`

Existing apps are not affected, since subsequent builds re-use the same version as used by the previous successful build (unless the build cache is cleared).

See here to find out more about the changes in these versions:
https://github.com/OSGeo/gdal/blob/v3.5.0/NEWS.md
https://proj.org/news.html

If any new apps using this buildpack now experience issues, either:
- update packages that depend on these libraries (such as the Python `GDAL` package) to a compatible version
- or, explicitly specify the library version to use (by setting env vars on the app; see README for more details) - and specify the versions that were the previous defaults:
   ```
   GDAL_VERSION=2.4.0
   PROJ_VERSION=5.2.0
   ```

Closes #20.
GUS-W-10346751.