### PR TITLE
Switch to the `heroku-buildpack-geo` S3 bucket

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ vendor_lib() {
     VENDOR_DIR=$3
 
     echo "-----> Installing $LIBRARY-$VERSION"
-    LIBRARY_URL="https://bucketeer-9aa8f376-a619-404c-b004-6db0317bcfe8.s3.amazonaws.com/$STACK/$LIBRARY/$LIBRARY-$VERSION.tar.gz"
+    LIBRARY_URL="https://heroku-buildpack-geo.s3.amazonaws.com/${STACK}/${LIBRARY}/${LIBRARY}-${VERSION}.tar.gz"
 
     mkdir -p "$VENDOR_DIR"
     if ! curl "${LIBRARY_URL}" -s | tar zxv -C "$VENDOR_DIR" &> /dev/null; then

--- a/builds/dependencies/utils.sh
+++ b/builds/dependencies/utils.sh
@@ -6,7 +6,7 @@ vendor_dependency() {
     VENDOR_DIR=$3
 
     echo "-----> Installing $DEP-$VERSION"
-    DEP_URL="https://bucketeer-9aa8f376-a619-404c-b004-6db0317bcfe8.s3.amazonaws.com/$STACK/$DEP/$DEP-$VERSION.tar.gz"
+    DEP_URL="https://heroku-buildpack-geo.s3.amazonaws.com/${STACK}/${DEP}/${DEP}-${VERSION}.tar.gz"
 
     mkdir -p "$VENDOR_DIR"
     if ! curl "${DEP_URL}" -sSf | tar zxv -C "$VENDOR_DIR"; then


### PR DESCRIPTION
Previously the assets for this buildpack were stored in an S3 bucket owned by a Bucketeer addon on a Heroku app, which is inconsistent with our other buildpacks, and adds an additional third-party into the supply chain. (It was set up this way, since the original buildpack author was on a different team and didn't have access to the required AWS account).

Now, a new `heroku-buildpack-geo` S3 bucket has been created, with the existing assets copied over.

GUS-W-11089566.