### PR TITLE
Update README to reflect that GDAL 2.x doesn't work on Heroku-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ You can change the version of each library that will be installed by setting the
 Available Versions
 ------------------
 
-- GDAL: `2.4.0`, `2.4.2`, `3.5.0`
+- GDAL:
+  - Heroku-18 + Heroku-20: `2.4.0`, `2.4.2`, `3.5.0`
+  - Heroku-22: `3.5.0`
 - GEOS:
   - Heroku-18: `3.7.2`
   - Heroku-20 + Heroku-22: `3.7.2`, `3.10.2`


### PR DESCRIPTION
See:
https://github.com/heroku/heroku-geo-buildpack/issues/43#issuecomment-1373690037

Closes #43.