### PR TITLE
Remove Heroku-18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     strategy:
       matrix:
         stack:
-          - name: heroku-18
-            image: heroku/heroku:18-build
           - name: heroku-20
             image: heroku/heroku:20-build
           - name: heroku-22

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-test-heroku-18:
-	@echo "Running tests in docker (heroku-18)..."
-	@docker run -v "$(shell pwd):/buildpack:ro" --rm -it -e "STACK=heroku-18" heroku/heroku:18-build bash -c '/buildpack/tests.sh'
-	@echo ""
-
 test-heroku-20:
 	@echo "Running tests in docker (heroku-20)..."
 	@docker run -v "$(shell pwd):/buildpack:ro" --rm -it -e "STACK=heroku-20" heroku/heroku:20-build bash -c '/buildpack/tests.sh'
@@ -12,19 +7,6 @@ test-heroku-22:
 	@echo "Running tests in docker (heroku-22)..."
 	@docker run -v "$(shell pwd):/buildpack:ro" --rm -it -e "STACK=heroku-20" heroku/heroku:22-build bash -c '/buildpack/tests.sh'
 	@echo ""
-
-build-heroku-18:
-	@echo "Creating build environment (heroku-18)..."
-	@echo
-	@docker build --pull -f "$(shell pwd)/builds/Dockerfile-heroku-18" -t buildenv-heroku-18 .
-	@echo
-	@echo "Usage..."
-	@echo
-	@echo "  $$ export S3_BUCKET='heroku-geo-buildpack' # Optional unless deploying"
-	@echo "  $$ export AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar  # Optional unless deploying"
-	@echo "  $$ ./builds/gdal/gdal-<version>.sh"
-	@echo
-	@docker run -e STACK="heroku-18" -e S3_BUCKET -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -it --rm buildenv-heroku-18
 
 build-heroku-20:
 	@echo "Creating build environment (heroku-20)..."

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Heroku Buildpack: Geo
 Heroku Buildpack Geo is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) that
 installs the Geo/GIS libraries [GDAL](https://www.gdal.org/), [GEOS](https://trac.osgeo.org/geos/) and [PROJ](https://proj4.org/)
 
-It can be used to get [GeoDjango](https://docs.djangoproject.com/en/2.1/ref/contrib/gis/) or [RGeo](https://github.com/rgeo/rgeo) running on Heroku.
+It can be used to get [GeoDjango](https://docs.djangoproject.com/en/4.2/ref/contrib/gis/) or [RGeo](https://github.com/rgeo/rgeo) running on Heroku.
 
 Usage
 -----
@@ -26,9 +26,7 @@ Default Versions
 The buildpack will install the following versions by default *for new apps*:
 
 - GDAL: `3.5.0`
-- GEOS:
-  - Heroku-18: `3.7.2`
-  - Heroku-20 + Heroku-22: `3.10.2`
+- GEOS: `3.10.2`
 - PROJ: `8.2.1`
 
 *Existing apps* that don't specify an explicit version will continue to use the
@@ -41,11 +39,9 @@ Available Versions
 ------------------
 
 - GDAL:
-  - Heroku-18 + Heroku-20: `2.4.0`, `2.4.2`, `3.5.0`
+  - Heroku-20: `2.4.0`, `2.4.2`, `3.5.0`
   - Heroku-22: `3.5.0`
-- GEOS:
-  - Heroku-18: `3.7.2`
-  - Heroku-20 + Heroku-22: `3.7.2`, `3.10.2`
+- GEOS: `3.7.2`, `3.10.2`
 - PROJ: `5.2.0`, `8.2.1`
 
 Migrating from heroku/python GEOs support

--- a/bin/compile
+++ b/bin/compile
@@ -32,11 +32,6 @@ DEFAULT_GDAL_VERSION="3.5.0"
 DEFAULT_GEOS_VERSION="3.10.2"
 DEFAULT_PROJ_VERSION="8.2.1"
 
-if [[ "${STACK}" == "heroku-18" ]]; then
-    # Newer GEOS requires CMake 3.13+ which isn't available on Ubuntu 18.04.
-    DEFAULT_GEOS_VERSION="3.7.2"
-fi
-
 if [ -f "$ENV_DIR/GDAL_VERSION" ]; then
     GDAL_VERSION=$(cat "$ENV_DIR/GDAL_VERSION")
 elif [ -f "$CACHE_DIR/.heroku-geo-buildpack/GDAL-version" ]; then

--- a/builds/Dockerfile-heroku-18
+++ b/builds/Dockerfile-heroku-18
@@ -1,7 +1,0 @@
-FROM heroku/heroku:18-build
-
-RUN apt-get -q update && apt-get -q -y --no-install-recommends install awscli libsqlite3-dev sqlite3
-
-ADD . /heroku-geo-buildpack
-
-WORKDIR "/heroku-geo-buildpack"

--- a/tests.sh
+++ b/tests.sh
@@ -40,13 +40,7 @@ testDefaultVersionInstall() {
   stdout=$(compile)
   assertEquals "0" "$?"
   assertContains "$stdout" "-----> Installing GDAL-3.5.0"
-
-  if [[ "${STACK}" == "heroku-18" ]]; then
-    assertContains "$stdout" "-----> Installing GEOS-3.7.2"
-  else
-    assertContains "$stdout" "-----> Installing GEOS-3.10.2"
-  fi
-
+  assertContains "$stdout" "-----> Installing GEOS-3.10.2"
   assertContains "$stdout" "-----> Installing PROJ-8.2.1"
 }
 


### PR DESCRIPTION
Since Heroku-18 is EOL:
https://devcenter.heroku.com/changelog-items/2583

In particular, removing the README references should prevent
the confusion seen in https://github.com/heroku/heroku-geo-buildpack/issues/45.

GUS-W-13981797.