### PR TITLE
Test and CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,30 +1,31 @@
 name: CI
+
 on:
-  - push
-  - pull_request
+  push:
+    # Avoid duplicate builds on PRs.
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt-get install shellcheck -y
+      - name: Checkout
+        uses: actions/checkout@v4
       - run: shellcheck -x bin/*
       - run: find . -name "*.sh" -exec shellcheck -x {} \;
 
-  shunit2:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        stack:
-          - name: heroku-20
-            image: heroku/heroku:20-build
-          - name: heroku-22
-            image: heroku/heroku:22-build
-    container: ${{ matrix.stack.image }}
+        stack_version: ["20", "22"]
     steps:
-      - uses: actions/checkout@v2
-      - run: ./tests.sh
-        env:
-          STACK: ${{ matrix.stack.name }}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - run: make test STACK_VERSION='${{ matrix.stack_version }}'

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,25 @@
-test-heroku-20:
-	@echo "Running tests in docker (heroku-20)..."
-	@docker run -v "$(shell pwd):/buildpack:ro" --rm -it -e "STACK=heroku-20" heroku/heroku:20-build bash -c '/buildpack/tests.sh'
-	@echo ""
+# These targets are not files
+.PHONY: compile test build-heroku-20 build-heroku-22
 
-test-heroku-22:
-	@echo "Running tests in docker (heroku-22)..."
-	@docker run -v "$(shell pwd):/buildpack:ro" --rm -it -e "STACK=heroku-20" heroku/heroku:22-build bash -c '/buildpack/tests.sh'
-	@echo ""
+STACK_VERSION ?= 22
+STACK := heroku-$(STACK_VERSION)
+BASE_BUILD_IMAGE := heroku/heroku:$(STACK_VERSION)-build
+PLATFORM := linux/amd64
+
+compile:
+	@echo "Running compile using: STACK_VERSION=$(STACK_VERSION)"
+	@echo "To use a different stack, run: 'make compile STACK_VERSION=NN'"
+	@echo
+	@docker run --rm --platform=$(PLATFORM) -v "$(PWD):/src:ro" -e "STACK=$(STACK)" -w /buildpack "$(BASE_BUILD_IMAGE)" \
+		bash -c 'cp -r /src/bin /buildpack && mkdir -p /tmp/{build,cache,env} && bin/compile /tmp/build /tmp/cache /tmp/env'
+	@echo
+
+test:
+	@echo "Running tests using: STACK_VERSION=$(STACK_VERSION)"
+	@echo "To use a different stack, run: 'make test STACK_VERSION=NN'"
+	@echo
+	@docker run --rm --platform=$(PLATFORM) -v "$(PWD):/buildpack:ro" -e "STACK=$(STACK)" "$(BASE_BUILD_IMAGE)" /buildpack/tests.sh
+	@echo
 
 build-heroku-20:
 	@echo "Creating build environment (heroku-20)..."

--- a/tests.sh
+++ b/tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 BASE_DIR=$(dirname "$0")
 
 oneTimeSetUp () {
@@ -42,6 +44,13 @@ testDefaultVersionInstall() {
   assertContains "$stdout" "-----> Installing GDAL-3.5.0"
   assertContains "$stdout" "-----> Installing GEOS-3.10.2"
   assertContains "$stdout" "-----> Installing PROJ-8.2.1"
+
+  # Cached build
+  stdout=$(compile)
+  assertEquals "0" "$?"
+  assertContains "$stdout" "-----> Installing GDAL-3.5.0"
+  assertContains "$stdout" "-----> Installing GEOS-3.10.2"
+  assertContains "$stdout" "-----> Installing PROJ-8.2.1"
 }
 
 testBuildpackEnv() {
@@ -67,6 +76,13 @@ testSpecifiedVersionInstall() {
   assertContains "$stdout" "-----> Installing GDAL-2.4.0"
   assertContains "$stdout" "-----> Installing GEOS-3.7.2"
   assertContains "$stdout" "-----> Installing PROJ-5.2.0"
+
+  # Cached build
+  stdout=$(compile)
+  assertEquals "0" "$?"
+  assertContains "$stdout" "-----> Installing GDAL-2.4.0"
+  assertContains "$stdout" "-----> Installing GEOS-3.7.2"
+  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
 }
 
 testUnavailableVersionInstall() {
@@ -77,9 +93,8 @@ testUnavailableVersionInstall() {
   assertContains "$stdout" "Requested GDAL Version (9.9.9) is not available for this stack ($STACK)."
 }
 
-
 command -v shunit2 || {
-  curl -sLo /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
+  curl -sSfL --retry 3 --retry-connrefused --connect-timeout 10 -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
   chmod +x /usr/local/bin/shunit2
 }
 # shellcheck disable=SC1091


### PR DESCRIPTION
- Add a new `test` Make target, that takes a `STACK_VERSION` argument instead of having hardcoded per-stack targets.
- Add a new `compile` Make target, that allows viewing a single buildpack invocation to help when developing locally.
- Add tests for cached builds (rebuilds).
- Make the test runner more robust against errors.
- Make CI use `make test` instead of manually running the test script.
- Update the CI dependencies and apply some best practices.