### PR TITLE
Include origin of versions in build output

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,10 +9,11 @@ vendor_lib() {
     LIBRARY_URL="https://heroku-buildpack-geo.s3.amazonaws.com/${STACK}/${LIBRARY}/${LIBRARY}-${VERSION}.tar.gz"
 
     mkdir -p "$VENDOR_DIR"
-    if ! curl "${LIBRARY_URL}" -s | tar zxv -C "$VENDOR_DIR" &> /dev/null; then
-      echo " !     Requested $LIBRARY Version ($VERSION) is not available for this stack ($STACK)."
-      echo " !     See: https://github.com/heroku/heroku-geo-buildpack#available-versions"
-      echo " !     Aborting."
+    if ! curl -sSf --retry 3 --retry-connrefused --connect-timeout 10 "${LIBRARY_URL}" | tar -zx -C "${VENDOR_DIR}"; then
+      echo " !     Error: ${LIBRARY} version '${VERSION}' is not available for this stack (${STACK})." >&2
+      echo " !     Try requesting a different version using the env var '${LIBRARY}_VERSION', or" >&2
+      echo " !     unset the env var and clear the build cache to use the default version." >&2
+      echo " !     See: https://github.com/heroku/heroku-geo-buildpack#available-versions" >&2
       exit 1
     fi
 
@@ -34,26 +35,35 @@ DEFAULT_PROJ_VERSION="8.2.1"
 
 if [ -f "$ENV_DIR/GDAL_VERSION" ]; then
     GDAL_VERSION=$(cat "$ENV_DIR/GDAL_VERSION")
+    echo "-----> Using GDAL version specified by GDAL_VERSION: ${GDAL_VERSION}."
 elif [ -f "$CACHE_DIR/.heroku-geo-buildpack/GDAL-version" ]; then
     GDAL_VERSION=$(cat "$CACHE_DIR/.heroku-geo-buildpack/GDAL-version")
+    echo "-----> GDAL_VERSION is not set. Using the same version as the last build: ${GDAL_VERSION}."
 else
     GDAL_VERSION=$DEFAULT_GDAL_VERSION
+    echo "-----> GDAL_VERSION is not set. Using the buildpack default: ${GDAL_VERSION}."
 fi
 
 if [ -f "$ENV_DIR/GEOS_VERSION" ]; then
     GEOS_VERSION=$(cat "$ENV_DIR/GEOS_VERSION")
+    echo "-----> Using GEOS version specified by GEOS_VERSION: ${GEOS_VERSION}."
 elif [ -f "$CACHE_DIR/.heroku-geo-buildpack/GEOS-version" ]; then
     GEOS_VERSION=$(cat "$CACHE_DIR/.heroku-geo-buildpack/GEOS-version")
+    echo "-----> GEOS_VERSION is not set. Using the same version as the last build: ${GEOS_VERSION}."
 else
     GEOS_VERSION=$DEFAULT_GEOS_VERSION
+    echo "-----> GEOS_VERSION is not set. Using the buildpack default: ${GEOS_VERSION}."
 fi
 
 if [ -f "$ENV_DIR/PROJ_VERSION" ]; then
     PROJ_VERSION=$(cat "$ENV_DIR/PROJ_VERSION")
+    echo "-----> Using PROJ version specified by PROJ_VERSION: ${PROJ_VERSION}."
 elif [ -f "$CACHE_DIR/.heroku-geo-buildpack/PROJ-version" ]; then
     PROJ_VERSION=$(cat "$CACHE_DIR/.heroku-geo-buildpack/PROJ-version")
+    echo "-----> PROJ_VERSION is not set. Using the same version as the last build: ${PROJ_VERSION}."
 else
     PROJ_VERSION=$DEFAULT_PROJ_VERSION
+    echo "-----> PROJ_VERSION is not set. Using the buildpack default: ${PROJ_VERSION}."
 fi
 
 vendor_lib "GDAL" "$GDAL_VERSION" "$VENDOR_DIR"

--- a/tests.sh
+++ b/tests.sh
@@ -41,6 +41,9 @@ setEnvVar () {
 testDefaultVersionInstall() {
   stdout=$(compile)
   assertEquals "0" "$?"
+  assertContains "$stdout" "-----> GDAL_VERSION is not set. Using the buildpack default: 3.5.0"
+  assertContains "$stdout" "-----> GEOS_VERSION is not set. Using the buildpack default: 3.10.2"
+  assertContains "$stdout" "-----> PROJ_VERSION is not set. Using the buildpack default: 8.2.1"
   assertContains "$stdout" "-----> Installing GDAL-3.5.0"
   assertContains "$stdout" "-----> Installing GEOS-3.10.2"
   assertContains "$stdout" "-----> Installing PROJ-8.2.1"
@@ -48,6 +51,9 @@ testDefaultVersionInstall() {
   # Cached build
   stdout=$(compile)
   assertEquals "0" "$?"
+  assertContains "$stdout" "-----> GDAL_VERSION is not set. Using the same version as the last build: 3.5.0"
+  assertContains "$stdout" "-----> GEOS_VERSION is not set. Using the same version as the last build: 3.10.2"
+  assertContains "$stdout" "-----> PROJ_VERSION is not set. Using the same version as the last build: 8.2.1"
   assertContains "$stdout" "-----> Installing GDAL-3.5.0"
   assertContains "$stdout" "-----> Installing GEOS-3.10.2"
   assertContains "$stdout" "-----> Installing PROJ-8.2.1"
@@ -73,6 +79,9 @@ testSpecifiedVersionInstall() {
 
   stdout=$(compile)
   assertEquals "0" "$?"
+  assertContains "$stdout" "-----> Using GDAL version specified by GDAL_VERSION: 2.4.0"
+  assertContains "$stdout" "-----> Using GEOS version specified by GEOS_VERSION: 3.7.2"
+  assertContains "$stdout" "-----> Using PROJ version specified by PROJ_VERSION: 5.2.0"
   assertContains "$stdout" "-----> Installing GDAL-2.4.0"
   assertContains "$stdout" "-----> Installing GEOS-3.7.2"
   assertContains "$stdout" "-----> Installing PROJ-5.2.0"
@@ -80,6 +89,9 @@ testSpecifiedVersionInstall() {
   # Cached build
   stdout=$(compile)
   assertEquals "0" "$?"
+  assertContains "$stdout" "-----> Using GDAL version specified by GDAL_VERSION: 2.4.0"
+  assertContains "$stdout" "-----> Using GEOS version specified by GEOS_VERSION: 3.7.2"
+  assertContains "$stdout" "-----> Using PROJ version specified by PROJ_VERSION: 5.2.0"
   assertContains "$stdout" "-----> Installing GDAL-2.4.0"
   assertContains "$stdout" "-----> Installing GEOS-3.7.2"
   assertContains "$stdout" "-----> Installing PROJ-5.2.0"
@@ -88,9 +100,10 @@ testSpecifiedVersionInstall() {
 testUnavailableVersionInstall() {
   setEnvVar "GDAL_VERSION" "9.9.9"
 
-  stdout=$(compile)
+  output=$(compile 2>&1)
   assertEquals "1" "$?"
-  assertContains "$stdout" "Requested GDAL Version (9.9.9) is not available for this stack ($STACK)."
+  assertContains "$output" "Error: GDAL version '9.9.9' is not available for this stack ($STACK)."
+  assertContains "$output" "Try requesting a different version using the env var 'GDAL_VERSION'"
 }
 
 command -v shunit2 || {


### PR DESCRIPTION
Previously the build output only stated what version of GDAL/GEOS/PROJ was being installed, and not why that version was chosen.

In particular, this made the "the version you requested doesn't exist for this stack" message confusing for the case where the user didn't pick a version, but instead the version was inherited from the previous build via the cache.

Now, the origin of the versions is logged.

In addition, the "version not available for this stack" message has been tweaked to not (falsely) suggest the version was always explicitly requested, plus explain how to adjust the version using the env var or clearing the build cache.

These changes should make stack upgrades less frustrating (such as for the upcoming Heroku-24 release).

Lastly, some best practices have been applied to the curl usage.