### PR TITLE
Update default GDAL/GEOS/PROJ versions & add support for Heroku-24

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack_version: ["20", "22"]
+        stack_version: ["20", "22", "24"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack_version: ["20", "22"]
+        stack_version: ["20", "22", "24"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # These targets are not files
 .PHONY: compile test buildenv
 
-STACK_VERSION ?= 22
+STACK_VERSION ?= 24
 STACK := heroku-$(STACK_VERSION)
 BASE_BUILD_IMAGE := heroku/heroku:$(STACK_VERSION)-build
 PLATFORM := linux/amd64
@@ -10,7 +10,7 @@ compile:
 	@echo "Running compile using: STACK_VERSION=$(STACK_VERSION)"
 	@echo "To use a different stack, run: 'make compile STACK_VERSION=NN'"
 	@echo
-	@docker run --rm --platform=$(PLATFORM) -v "$(PWD):/src:ro" -e "STACK=$(STACK)" -w /buildpack "$(BASE_BUILD_IMAGE)" \
+	@docker run --rm --platform=$(PLATFORM) --user root -v "$(PWD):/src:ro" -e "STACK=$(STACK)" -w /buildpack "$(BASE_BUILD_IMAGE)" \
 		bash -c 'cp -r /src/bin /buildpack && mkdir -p /tmp/{build,cache,env} && bin/compile /tmp/build /tmp/cache /tmp/env'
 	@echo
 
@@ -18,7 +18,7 @@ test:
 	@echo "Running tests using: STACK_VERSION=$(STACK_VERSION)"
 	@echo "To use a different stack, run: 'make test STACK_VERSION=NN'"
 	@echo
-	@docker run --rm --platform=$(PLATFORM) -v "$(PWD):/buildpack:ro" -e "STACK=$(STACK)" "$(BASE_BUILD_IMAGE)" /buildpack/tests.sh
+	@docker run --rm --platform=$(PLATFORM) --user root -v "$(PWD):/buildpack:ro" -e "STACK=$(STACK)" "$(BASE_BUILD_IMAGE)" /buildpack/tests.sh
 	@echo
 
 buildenv:

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Default Versions
 
 The buildpack will install the following versions by default *for new apps*:
 
-- GDAL: `3.5.0`
-- GEOS: `3.10.2`
-- PROJ: `8.2.1`
+- GDAL: `3.9.0`
+- GEOS: `3.12.1`
+- PROJ: `9.4.0`
 
 Note: *Existing apps* that don't specify an explicit version will continue to use the
 version used by the last successful build (unless the
@@ -42,20 +42,20 @@ Available Versions
 - GDAL:
   - `2.4.0` (Heroku-20 only)
   - `2.4.2` (Heroku-20 only)
-  - `3.5.0`
+  - `3.5.0` (Heroku-20 and Heroku-22 only)
   - `3.6.4`
   - `3.7.3`
   - `3.8.5`
   - `3.9.0`
 - GEOS:
-  - `3.7.2`
-  - `3.10.2`
+  - `3.7.2` (Heroku-20 and Heroku-22 only)
+  - `3.10.2` (Heroku-20 and Heroku-22 only)
   - `3.10.6`
   - `3.11.3`
   - `3.12.1`
 - PROJ:
-  - `5.2.0`
-  - `8.2.1`
+  - `5.2.0` (Heroku-20 and Heroku-22 only)
+  - `8.2.1` (Heroku-20 and Heroku-22 only)
   - `9.4.0`
 
 Migrating from heroku/python GEO support

--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ vendor_lib() {
     VENDOR_DIR=$3
 
     echo "-----> Installing $LIBRARY-$VERSION"
-    LIBRARY_URL="https://heroku-buildpack-geo.s3.amazonaws.com/${STACK}/${LIBRARY}/${LIBRARY}-${VERSION}.tar.gz"
+    LIBRARY_URL="https://heroku-buildpack-geo.s3.us-east-1.amazonaws.com/${STACK}/${LIBRARY}/${LIBRARY}-${VERSION}.tar.gz"
 
     mkdir -p "$VENDOR_DIR"
     if ! curl -sSf --retry 3 --retry-connrefused --connect-timeout 10 "${LIBRARY_URL}" | tar -zx -C "${VENDOR_DIR}"; then
@@ -29,9 +29,9 @@ BP_DIR=$(cd "$(dirname "${0:-}")" || exit 1 ; cd ..; pwd)
 
 VENDOR_DIR="$BUILD_DIR/.heroku-geo-buildpack/vendor"
 
-DEFAULT_GDAL_VERSION="3.5.0"
-DEFAULT_GEOS_VERSION="3.10.2"
-DEFAULT_PROJ_VERSION="8.2.1"
+DEFAULT_GDAL_VERSION="3.9.0"
+DEFAULT_GEOS_VERSION="3.12.1"
+DEFAULT_PROJ_VERSION="9.4.0"
 
 if [ -f "$ENV_DIR/GDAL_VERSION" ]; then
     GDAL_VERSION=$(cat "$ENV_DIR/GDAL_VERSION")

--- a/tests.sh
+++ b/tests.sh
@@ -41,22 +41,22 @@ setEnvVar () {
 testDefaultVersionInstall() {
   stdout=$(compile)
   assertEquals "0" "$?"
-  assertContains "$stdout" "-----> GDAL_VERSION is not set. Using the buildpack default: 3.5.0"
-  assertContains "$stdout" "-----> GEOS_VERSION is not set. Using the buildpack default: 3.10.2"
-  assertContains "$stdout" "-----> PROJ_VERSION is not set. Using the buildpack default: 8.2.1"
-  assertContains "$stdout" "-----> Installing GDAL-3.5.0"
-  assertContains "$stdout" "-----> Installing GEOS-3.10.2"
-  assertContains "$stdout" "-----> Installing PROJ-8.2.1"
+  assertContains "$stdout" "-----> GDAL_VERSION is not set. Using the buildpack default: 3.9.0"
+  assertContains "$stdout" "-----> GEOS_VERSION is not set. Using the buildpack default: 3.12.1"
+  assertContains "$stdout" "-----> PROJ_VERSION is not set. Using the buildpack default: 9.4.0"
+  assertContains "$stdout" "-----> Installing GDAL-3.9.0"
+  assertContains "$stdout" "-----> Installing GEOS-3.12.1"
+  assertContains "$stdout" "-----> Installing PROJ-9.4.0"
 
   # Cached build
   stdout=$(compile)
   assertEquals "0" "$?"
-  assertContains "$stdout" "-----> GDAL_VERSION is not set. Using the same version as the last build: 3.5.0"
-  assertContains "$stdout" "-----> GEOS_VERSION is not set. Using the same version as the last build: 3.10.2"
-  assertContains "$stdout" "-----> PROJ_VERSION is not set. Using the same version as the last build: 8.2.1"
-  assertContains "$stdout" "-----> Installing GDAL-3.5.0"
-  assertContains "$stdout" "-----> Installing GEOS-3.10.2"
-  assertContains "$stdout" "-----> Installing PROJ-8.2.1"
+  assertContains "$stdout" "-----> GDAL_VERSION is not set. Using the same version as the last build: 3.9.0"
+  assertContains "$stdout" "-----> GEOS_VERSION is not set. Using the same version as the last build: 3.12.1"
+  assertContains "$stdout" "-----> PROJ_VERSION is not set. Using the same version as the last build: 9.4.0"
+  assertContains "$stdout" "-----> Installing GDAL-3.9.0"
+  assertContains "$stdout" "-----> Installing GEOS-3.12.1"
+  assertContains "$stdout" "-----> Installing PROJ-9.4.0"
 }
 
 testBuildpackEnv() {
@@ -73,28 +73,28 @@ testBuildpackEnv() {
 testSpecifiedVersionInstall() {
   # The versions here should ideally not match the default versions,
   # so that we're testing that it really overrides the defaults.
-  setEnvVar "GDAL_VERSION" "2.4.0"
-  setEnvVar "GEOS_VERSION" "3.7.2"
-  setEnvVar "PROJ_VERSION" "5.2.0"
+  setEnvVar "GDAL_VERSION" "3.8.5"
+  setEnvVar "GEOS_VERSION" "3.11.3"
+  setEnvVar "PROJ_VERSION" "9.4.0"
 
   stdout=$(compile)
   assertEquals "0" "$?"
-  assertContains "$stdout" "-----> Using GDAL version specified by GDAL_VERSION: 2.4.0"
-  assertContains "$stdout" "-----> Using GEOS version specified by GEOS_VERSION: 3.7.2"
-  assertContains "$stdout" "-----> Using PROJ version specified by PROJ_VERSION: 5.2.0"
-  assertContains "$stdout" "-----> Installing GDAL-2.4.0"
-  assertContains "$stdout" "-----> Installing GEOS-3.7.2"
-  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
+  assertContains "$stdout" "-----> Using GDAL version specified by GDAL_VERSION: 3.8.5"
+  assertContains "$stdout" "-----> Using GEOS version specified by GEOS_VERSION: 3.11.3"
+  assertContains "$stdout" "-----> Using PROJ version specified by PROJ_VERSION: 9.4.0"
+  assertContains "$stdout" "-----> Installing GDAL-3.8.5"
+  assertContains "$stdout" "-----> Installing GEOS-3.11.3"
+  assertContains "$stdout" "-----> Installing PROJ-9.4.0"
 
   # Cached build
   stdout=$(compile)
   assertEquals "0" "$?"
-  assertContains "$stdout" "-----> Using GDAL version specified by GDAL_VERSION: 2.4.0"
-  assertContains "$stdout" "-----> Using GEOS version specified by GEOS_VERSION: 3.7.2"
-  assertContains "$stdout" "-----> Using PROJ version specified by PROJ_VERSION: 5.2.0"
-  assertContains "$stdout" "-----> Installing GDAL-2.4.0"
-  assertContains "$stdout" "-----> Installing GEOS-3.7.2"
-  assertContains "$stdout" "-----> Installing PROJ-5.2.0"
+  assertContains "$stdout" "-----> Using GDAL version specified by GDAL_VERSION: 3.8.5"
+  assertContains "$stdout" "-----> Using GEOS version specified by GEOS_VERSION: 3.11.3"
+  assertContains "$stdout" "-----> Using PROJ version specified by PROJ_VERSION: 9.4.0"
+  assertContains "$stdout" "-----> Installing GDAL-3.8.5"
+  assertContains "$stdout" "-----> Installing GEOS-3.11.3"
+  assertContains "$stdout" "-----> Installing PROJ-9.4.0"
 }
 
 testUnavailableVersionInstall() {


### PR DESCRIPTION
Updates the default package versions as follows:
- GDAL: 3.5.0 -> 3.9.0
- GEOS: 3.10.2 -> 3.12.1
- PROJ: 8.2.1 -> 9.4.0

Existing apps that don't request a specific version will be unaffected, since they will continue to use the version used for the last successful build unless their build cache is cleared. 

To override the versions set `GDAL_VERSION`, `GEOS_VERSION` and `PROJ_VERSION` accordingly. See:
https://github.com/heroku/heroku-geo-buildpack#default-versions

And adds support for Heroku-24.

GUS-W-14674586.