### PR TITLE
Switch to AWS' dual-stack S3 URLs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ vendor_lib() {
     VENDOR_DIR=$3
 
     echo "-----> Installing $LIBRARY-$VERSION"
-    LIBRARY_URL="https://heroku-buildpack-geo.s3.us-east-1.amazonaws.com/${STACK}/${LIBRARY}/${LIBRARY}-${VERSION}.tar.gz"
+    LIBRARY_URL="https://heroku-buildpack-geo.s3.dualstack.us-east-1.amazonaws.com/${STACK}/${LIBRARY}/${LIBRARY}-${VERSION}.tar.gz"
 
     mkdir -p "$VENDOR_DIR"
     if ! curl -sSf --retry 3 --retry-connrefused --connect-timeout 10 "${LIBRARY_URL}" | tar -zx -C "${VENDOR_DIR}"; then

--- a/builds/utils.sh
+++ b/builds/utils.sh
@@ -4,7 +4,7 @@ vendor_dependency() {
   local DEP="${1}"
   local VERSION="${2}"
   local VENDOR_DIR="${3}"
-  local DEP_URL="https://heroku-buildpack-geo.s3.us-east-1.amazonaws.com/${STACK}/${DEP}/${DEP}-${VERSION}.tar.gz"
+  local DEP_URL="https://heroku-buildpack-geo.s3.dualstack.us-east-1.amazonaws.com/${STACK}/${DEP}/${DEP}-${VERSION}.tar.gz"
 
   if ! curl -sSf --retry 3 --retry-connrefused --connect-timeout 10 --max-time 60 "${DEP_URL}" | tar --gzip --extract --directory "${VENDOR_DIR}"; then
     echo "Error: Dependency ${DEP} ${VERSION} for ${STACK} not found on S3. Make sure it is built first." >&2


### PR DESCRIPTION
The default AWS S3 URLs only support IPv4, whereas the dual-stack URLs support both IPv4 and IPv6:
https://docs.aws.amazon.com/AmazonS3/latest/API/ipv6-access.html
https://docs.aws.amazon.com/AmazonS3/latest/API/dual-stack-endpoints.html

By switching to the dual-stack URLs, it means systems that support IPv6 will now use it instead of IPv4, which is helpful in IPv6 environments where IPv4 traffic has to fall back to being routed via NAT gateways (which has performance and ingress cost implications).

See also:
https://salesforce-internal.slack.com/archives/C01R6FJ738U/p1770827176094169

GUS-W-21348027.